### PR TITLE
Use existing spec-coerce library for coercions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 /.idea
 /*.iml
+.cpcache

--- a/README.md
+++ b/README.md
@@ -314,15 +314,23 @@ Or any other custom conversion:
 Note also that spec-coerce honors the "first" or "left-most" spec condition of `s/and` specs for coercion. So, when using one of the basic predicates (like `keyword?` or `int?`) for coercing, you can specify the general coercion spec first and then the more granular constraints afterward to avoid the need for an `sc/def` line:
 
 ```clj
-(s/def ::a-b-or-c (s/and keyword? #{:a :b :c}))
+(s/def ::my-number (s/and int? (s/int-in 0 2)))
 ;; Is the same as:
-(s/def ::a-b-or-c #{:a :b :c})
-(sc/def ::a-b-or-c keyword?)
+(s/def ::my-number (s/int-in 0 2))
+(sc/def ::my-number sc/parse-long)
 ```
 
 See [spec-coerce's usage](https://github.com/wilkerlucio/spec-coerce#usage) for more details and options.
 
-NOTE: Taking this approach may hamper your ability to generate sample data from these specs. `::a-b-or-c` above cannot easily be generated, because the `keyword?` case is very broad and the `#{:a :b :c}` case is very narrow. It seems spec's generator logic also reads left-to-right in this sense.
+NOTE: Taking this approach may hamper your ability to generate sample data from these specs. `::my-number` will sometimes fail to generate after 100 tries, because the `int?` case is very broad and the `s/int-in` case is very narrow. It seems spec's generator logic also reads left-to-right in this sense. 
+
+A better solution to the specific `::my-number` example above would be to use a homogeneous set:
+
+```clj
+(s/def ::my-number #{0 1})
+```
+
+spec-coerce will infer from this set that it needs to parse as an integer. 
 
 #### Prismatic Schema
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ and then transforms, validates and summarizes it.
 *http.clj:*
 ```clj
 (ns my.http
-  (:require [cyrus-config.core :as cfg]))
+  (:require [cyrus-config.core :as cfg]
+            [clojure.spec.alpha :as s]))
 
 ;; Introduce a configuration constant that will contain validated and transformed value from the environment
 ;; By default uses variable name transformed from the defined name: "HTTP_PORT"
-(cfg/def HTTP_PORT "Port to listen on" {:spec     int?
+
+(s/def ::port int?)
+(cfg/def HTTP_PORT "Port to listen on" {:spec     ::port
                                         :default  8080})
 
 ;; Available immediately, without additional loading commands, but can contain a special value indicating an error.
@@ -91,12 +94,12 @@ This metadata is used in `(cfg/show)`.
 HTTP_PORT
 => 8080
 (meta #'HTTP_PORT)
-=> {::cfg/user-spec      {:spec #object[clojure.core$int_QMARK___5132 ...]}
+=> {::cfg/user-spec      {:spec :my.http/port}
     ::cfg/effective-spec {:required true
                           :default  nil
                           :secret   false
                           :var-name "HTTP_PORT"
-                          :spec     #object[clojure.core$int_QMARK___5132 ...]}
+                          :spec     :my.http/port}
     ::cfg/source         :environment
     ::cfg/raw-value      "8080"
     ::cfg/error          nil
@@ -129,8 +132,7 @@ will silently get a special value that indicates an error, for example:
 
     ```
 * `:default` — default value to use if the variable is not set. Cannot be used together with `:required true`. Defaults to `nil`.
-* `:spec` — Clojure Spec to conform the value to. Defaults to `string?`, can also be `int?`, `keyword?`, `double?` and 
-  any complex spec, in which case the original value will be parsed as EDN and then conformed. See Conforming/Coercing section below. 
+* `:spec` — Clojure Spec to conform the value to. Defaults to string. Specs must be provided as fully-qualified registered keywords. See Conforming/Coercing section below. 
 * `:schema` — Prismatic Schema to coerce the value to (same as `:spec`, but for Prismatic). Complex schemas first parse the value as YAML.
 * `:secret` — boolean, if true, the value will not be displayed in the overview returned by `(cfg/show)`:
     ```
@@ -140,10 +142,11 @@ will silently get a special value that indicates an error, for example:
 You can also use existing configuration constants' values when defining configuration constants:
 
 ```clj
+(s/def ::server-polling-interval int?)
 (cfg/def SERVER_URL)
 
 ;; This constant will only be required if SERVER_URL is set
-(cfg/def SERVER_POLLING_INTERVAL {:required (some? SERVER_URL) :spec int?})
+(cfg/def SERVER_POLLING_INTERVAL {:required (some? SERVER_URL) :spec ::server-polling-interval})
 
 ;; This will get default value from SERVER_POLLING_INTERVAL, when it's set (it also has a different type)
 (cfg/def SERVER_POLLING_DELAY {:default SERVER_POLLING_INTERVAL})
@@ -163,7 +166,8 @@ The output looks like this:
 cyrus-config.core/validate!  core.clj:  146
        clojure.core/ex-info  core.clj: 4739
 clojure.lang.ExceptionInfo: Errors found when loading config:
-                            #'my.http/HTTP_PORT: <ERROR> because HTTP_PORT contains "abcd" in :environment - java.lang.NumberFormatException: For input string: "abcd" // Port to listen on
+
+                            #'my.http/HTTP_PORT: <ERROR> because HTTP_PORT contains "abcd" in :environment - clojure.lang.ExceptionInfo: Failed to coerce value {:spec :my.http/port, :value "abcd"} // Port to listen on
 ```
 
 #### Summary
@@ -217,20 +221,26 @@ This will ensure that every time the code is reloaded, the overrides file `dev-e
 ### Conforming/Coercion
 
 The library supports two ways of conforming (a.k.a. coercing) environment values (which are always string) to
-various types: integer, keyword, double, etc. The ways of defining targer types are Clojure Spec and Prismatic Schema.
+various types: integer, keyword, double, etc. The ways of defining target types are Clojure Spec and Prismatic Schema.
 They are mutually exclusive, i.e. only one of `:spec` and `:schema` keys are possible at the same time for each configuration constant.
 
 #### Clojure Spec
 
 > [spec] is a Clojure library to describe the structure of data and functions.
 
-It is enabled by setting `:spec` key in the parameters:
+The Clojure Spec coercion implementation is provided by [spec-coerce](https://github.com/wilkerlucio/spec-coerce). It is enabled by setting `:spec` key in the parameters:
 
 ```clj
-(cfg/def HTTP_PORT {:spec int?})
+(s/def ::port int?)
+(cfg/def HTTP_PORT {:spec ::port})
 ```
 
-Implicit coercion is in place for basic types: `int?`, `double?`, `boolean?`, keyword?`, `string?` (the default one, does nothing). 
+Implicit coercion is in place for basic types: `int?`, `double?`, `boolean?`, `keyword?`, `string?` (the default one does nothing). But note that you must provide the spec in the form of a registered, fully-qualified keyword as defined by `s/def`. It's expected that you will be defining these on your own (as in the example of `::port` above), but if you'd rather not, there are some stand-in specs for the basic types located under `cyrus-config.coerce`:
+- :cyrus-config.coerce/int
+- :cyrus-config.coerce/double
+- :cyrus-config.coerce/keyword
+- :cyrus-config.coerce/string
+- :cyrus-config.coerce/boolean
 
 ##### Custom coercions
 
@@ -258,10 +268,15 @@ Additionally, you can put a complex value in EDN format into the variable:
 
     IP_WHITELIST='["1.2.3.4" "4.3.2.1"]'
 
-and then conform it:
+and then define how to coerce it using spec-coerce's `def` form:
 
 ```clj
-(cfg/def IP_WHITELIST {:spec (cfgc/from-edn (s/coll-of string?))})
+(require '[spec-coerce.core :as sc]
+         '[clojure.spec.alpha :as s]
+         '[clojure.edn :as edn])
+(s/def ::ip-whitelist (s/coll-of string?))
+(sc/def ::ip-whitelist edn/read-string)
+(cfg/def IP_WHITELIST {:spec ::ip-whitelist})
 IP_WHITELIST
 => ["1.2.3.4" "4.3.2.1"]
 ;; ^ not a string, a Clojure data structure
@@ -272,7 +287,8 @@ Alternatively, you can use JSON format:
     IP_WHITELIST='["1.2.3.4", "4.3.2.1"]'
 
 ```clj
-(cfg/def IP_WHITELIST {:spec (cfgc/from-custom-parser json/parse-string (s/coll-of string?))})
+(require '[cheshire.core :as json])
+(sc/def ::ip-whitelist json/parse-string)
 ```
 
 Or any other custom conversion:
@@ -286,17 +302,27 @@ Or any other custom conversion:
     (->> (str/split (str csv) #",")
          (map str/trim))))
 
-(cfg/def IP_WHITELIST {:spec (s/conformer parse-csv)})
+(sc/def ::ip-whitelist parse-csv)
 ```
-
-In this case, conversion is considered successful if it does not throw an exception.
 
 `if (sequential? csv)` condition is important, it allows to provide `:default` not only as string, but also as target type:
 
 ```clj
-(cfg/def IP_WHITELIST {:spec (s/conformer parse-csv) :default ["one" "two"]})
+(cfg/def IP_WHITELIST {:spec ::ip-whitelist :default ["one" "two"]})
 ```
 
+Note also that spec-coerce honors the "first" or "left-most" spec condition of `s/and` specs for coercion. So, when using one of the basic predicates (like `keyword?` or `int?`) for coercing, you can specify the general coercion spec first and then the more granular constraints afterward to avoid the need for an `sc/def` line:
+
+```clj
+(s/def ::a-b-or-c (s/and keyword? #{:a :b :c}))
+;; Is the same as:
+(s/def ::a-b-or-c #{:a :b :c})
+(sc/def ::a-b-or-c keyword?)
+```
+
+See [spec-coerce's usage](https://github.com/wilkerlucio/spec-coerce#usage) for more details and options.
+
+NOTE: Taking this approach may hamper your ability to generate sample data from these specs. `::a-b-or-c` above cannot easily be generated, because the `keyword?` case is very broad and the `#{:a :b :c}` case is very narrow. It seems spec's generator logic also reads left-to-right in this sense.
 
 #### Prismatic Schema
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
            spec-coerce
            {;;:mvn/version "1.0.0-alpha13"
             :git/url "https://github.com/WhittlesJr/spec-coerce.git"
-            :sha     "aabe79a695a2caa93a8cbccd11a7b484bd09324b"}}
+            :sha     "334e5a58c31ba333e8ea285b84050fa67f8238ce"}}
  :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {cheshire {:mvn/version "5.8.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
            spec-coerce
            {;;:mvn/version "1.0.0-alpha13"
             :git/url "https://github.com/WhittlesJr/spec-coerce.git"
-            :sha     "334e5a58c31ba333e8ea285b84050fa67f8238ce"}}
+            :sha     "88cbce6c306ffc066f583a4d19abbea5860890a8"}}
  :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {cheshire {:mvn/version "5.8.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,6 @@
 {:deps    {org.clojure/clojure {:mvn/version "1.10.0"}
            squeeze             {:mvn/version "0.3.3"}
-           spec-coerce
-           {;;:mvn/version "1.0.0-alpha13"
-            :git/url "https://github.com/wilkerlucio/spec-coerce.git"
-            :sha     "0d5515ef3a1a61a92c6bad5b12809ee98876a541"}}
+           spec-coerce         {:mvn/version "1.0.0-alpha14"}}
  :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {cheshire {:mvn/version "5.8.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
            spec-coerce
            {;;:mvn/version "1.0.0-alpha13"
             :git/url "https://github.com/WhittlesJr/spec-coerce.git"
-            :sha     "58340d9ebe930142a192e7693f61d5e2f11ee1fb"}}
+            :sha     "aabe79a695a2caa93a8cbccd11a7b484bd09324b"}}
  :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {cheshire {:mvn/version "5.8.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,8 @@
            squeeze             {:mvn/version "0.3.3"}
            spec-coerce
            {;;:mvn/version "1.0.0-alpha13"
-            :git/url "https://github.com/WhittlesJr/spec-coerce.git"
-            :sha     "88cbce6c306ffc066f583a4d19abbea5860890a8"}}
+            :git/url "https://github.com/wilkerlucio/spec-coerce.git"
+            :sha     "0d5515ef3a1a61a92c6bad5b12809ee98876a541"}}
  :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {cheshire {:mvn/version "5.8.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,14 @@
+{:deps    {org.clojure/clojure {:mvn/version "1.10.0"}
+           squeeze             {:mvn/version "0.3.3"}
+           spec-coerce
+           {;;:mvn/version "1.0.0-alpha13"
+            :git/url "https://github.com/WhittlesJr/spec-coerce.git"
+            :sha     "58340d9ebe930142a192e7693f61d5e2f11ee1fb"}}
+ :aliases {:dev  {:extra-deps {cheshire {:mvn/version "5.8.1"}}}
+           :test {:extra-paths ["test"]
+                  :extra-deps  {cheshire {:mvn/version "5.8.1"}
+                                com.cognitect/test-runner
+                                {:git/url "git@github.com:cognitect-labs/test-runner"
+                                 :sha     "76568540e7f40268ad2b646110f237a60295fa3c"}}
+                  :main-opts   ["-m" "cognitect.test-runner"]}}
+ :paths   ["src"]}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/dryewo/cyrus-config"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies []
+  :dependencies [[spec-coerce "1.0.0-alpha13"]]
   :plugins [[lein-cloverage "1.0.13"]
             [lein-shell "0.5.0"]
             [lein-ancient "0.6.15"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/dryewo/cyrus-config"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[spec-coerce "1.0.0-alpha13"]]
+  :dependencies [[spec-coerce "1.0.0-alpha14"]]
   :plugins [[lein-cloverage "1.0.13"]
             [lein-shell "0.5.0"]
             [lein-ancient "0.6.15"]

--- a/src/cyrus_config/coerce.clj
+++ b/src/cyrus_config/coerce.clj
@@ -1,77 +1,26 @@
 (ns cyrus-config.coerce
   (:require [clojure.spec.alpha :as s]
-            [clojure.edn :as edn]
-            [clojure.string :as str]))
-
+            [clojure.string :as str]
+            [spec-coerce.core :as sc]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Custom parsers
-
-
-(defn wrapped-string-parser [parser-fn]
-  (fn [data]
-    (if (string? data)
-      (try
-        (parser-fn data)
-        (catch Exception _ ::s/invalid))
-      data)))
-
-
-(defmacro from-custom-parser [parser-fn spec]
-  `(s/and
-     (s/spec-impl '~parser-fn (wrapped-string-parser ~parser-fn) nil true)
-     ~spec))
-
-
-(defn from-edn [spec]
-  (from-custom-parser edn/read-string spec))
-
 
 (defn unblank [s]
   (let [str-s (str s)]
     (when-not (str/blank? str-s)
       str-s)))
 
+(s/def ::nonblank-string (s/nilable string?))
+(sc/def ::nonblank-string unblank)
 
-(s/def ::nonblank-string (s/conformer unblank))
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-
-(defn wrapped-parser [spec parser-fn]
-  (fn [data]
-    (if (s/valid? spec data)
-      data
-      (try
-        (parser-fn (str data))
-        (catch Exception _ ::s/invalid)))))
-
-
-;; TODO make it look pretty: {int? 'Integer/parseInt double? 'Double/parseDouble ...}
-(def known-parsers
-  {int?     (s/spec-impl 'Integer/parseInt (wrapped-parser int? #(Integer/parseInt %)) nil true)
-   double?  (s/spec-impl 'Double/parseDouble (wrapped-parser double? #(Double/parseDouble %)) nil true)
-   boolean? (s/spec-impl 'Boolean/parseBoolean (wrapped-parser boolean? #(Boolean/parseBoolean %)) nil true)
-   keyword? (s/spec-impl 'keyword (wrapped-parser keyword? #(keyword %)) nil true)
-   string?  (s/conformer str)})
-
-
-(defn conformer-for-spec [spec]
-  (get known-parsers spec spec))
-
-
-(defn coerce-to-spec [spec data]
-  (let [spec-with-conformer (conformer-for-spec spec)
-        result              (s/conform spec-with-conformer data)]
-    (if (= result ::s/invalid)
-      (throw (Exception. (str "Error coercing " (pr-str data) ": "
-                              (str/trim-newline (s/explain-str spec-with-conformer data)))))
-      result)))
-
+(s/def ::int int?)
+(s/def ::double double?)
+(s/def ::keyword keyword?)
+(s/def ::string string?)
+(s/def ::boolean boolean?)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 
 (def ^:private squeeze-coerce-to-schema
   (try

--- a/src/cyrus_config/core.clj
+++ b/src/cyrus_config/core.clj
@@ -1,6 +1,7 @@
 (ns cyrus-config.core
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
+            [spec-coerce.core :as sc]
             [cyrus-config.coerce :as c])
   (:import (java.io Writer)
            (java.util LinkedHashSet)
@@ -38,6 +39,7 @@
 (s/def ::secret boolean?)
 (s/def ::var-name (s/or :string string? :keyword keyword?))
 (s/def ::config-definition (s/keys :opt-un [::spec ::schema ::required ::default ::secret ::var-name]))
+(s/def ::default-coercion-spec string?)
 
 (s/fdef effective-config-definition
   :args (s/cat :name symbol? :definition ::config-definition))
@@ -77,11 +79,11 @@
                           (try
                             (cond
                               spec
-                              [(c/coerce-to-spec spec raw-value)]
+                              [(sc/coerce! spec raw-value)]
                               schema
                               [(c/coerce-to-schema schema raw-value)]
                               :else
-                              [(c/coerce-to-spec string? raw-value)])
+                              [(sc/coerce! ::default-coercion-spec raw-value)])
                             (catch Exception e
                               (let [error {:code ::invalid-value :value raw-value :message (str e)}]
                                 [(ConfigNotLoaded. error) error])))))]

--- a/test/cyrus_config/coerce_test.clj
+++ b/test/cyrus_config/coerce_test.clj
@@ -1,11 +1,12 @@
 (ns cyrus-config.coerce-test
-  (:require [clojure.test :refer :all]
-            [cyrus-config.coerce :refer :all :as c]
+  (:require [cheshire.core :as json]
+            [clojure.edn :as edn]
             [clojure.spec.alpha :as s]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [cyrus-config.coerce :as c :refer :all]
             [schema.core :as ps]
-            [cheshire.core :as json]
-            [clojure.string :as str]))
-
+            [spec-coerce.core :as sc]))
 
 (defn parse-csv [csv]
   (if (sequential? csv)
@@ -13,49 +14,81 @@
     (->> (str/split (str csv) #",")
          (map str/trim))))
 
+(defn parse-json [x]
+  (if (string? x)
+    (json/parse-string x)
+    x))
+
+(defn parse-edn [x]
+  (if (string? x)
+    (try (edn/read-string x)
+         (catch RuntimeException e x))
+    x))
+
+(s/def ::csv (s/conformer parse-csv))
+(sc/def ::csv parse-csv)
+
+(s/def ::json-coll-of-int (s/coll-of ::c/int))
+(sc/def ::json-coll-of-int parse-json)
+
+(s/def ::json-string-keyed-map (s/map-of ::c/string any?))
+(sc/def ::json-string-keyed-map parse-json)
+
+(s/def ::edn-coll-of-int (s/coll-of ::c/int))
+(sc/def ::edn-coll-of-int parse-edn)
+
+(s/def ::branching (s/or :kw (s/and keyword? #{:a})
+                         :num ::c/int))
+
+
+(= (sc/coerce! ::json-coll-of-int "[1, 2, 3]") [1 2 3])
 
 (deftest to-spec
   (testing "Coercions work and are idempotent"
     (are [?in ?spec ?out]
-      (do (is (= ?out (coerce-to-spec ?spec ?in)))
-          (is (= ?out (coerce-to-spec ?spec ?out))))
+        (do (is (= ?out (sc/coerce! ?spec ?in)))
+            (is (= ?out (sc/coerce! ?spec ?out))))
 
-      "123" int? 123
-      "1.5" double? 1.5
-      1 double? 1.0
-      12345 string? "12345"
-      "foo" keyword? :foo
-      'foo keyword? :foo
-
-      "" ::c/nonblank-string nil
-      "  " ::c/nonblank-string nil
-      " 1/ " ::c/nonblank-string " 1/ "
-
-      ;; From a custom conformer
-      "one,two" (s/conformer parse-csv) ["one" "two"]
-
-      ;; From JSON
-      "[1, 2, 3]" (from-custom-parser json/parse-string (s/coll-of int?)) [1 2 3]
-      "{\"foo\": 1, \"bar\": true}" (from-custom-parser json/parse-string (s/map-of string? any?)) {"foo" 1 "bar" true}
-
-      ;; From EDN
-      "[1 2 3]" (from-edn (s/coll-of int?)) [1 2 3]))
+      "123"                         ::c/int                 123
+      "1.5"                         ::c/double              1.5
+      1                             ::c/double              1.0
+      12345                         ::c/string              "12345"
+      "foo"                         ::c/keyword             :foo
+      'foo                          ::c/keyword             :foo
+      ""                            ::c/nonblank-string     nil
+      "  "                          ::c/nonblank-string     nil
+      " 1/ "                        ::c/nonblank-string     " 1/ "
+      "one,two"                     ::csv                   ["one" "two"]
+      "[1, 2, 3]"                   ::json-coll-of-int      [1 2 3]
+      "{\"foo\": 1, \"bar\": true}" ::json-string-keyed-map {"foo" 1 "bar" true}
+      "[1 2 3]"                     ::edn-coll-of-int       [1 2 3]))
 
   (testing "Throws good error messages"
-    (are [in? ?spec ?exception-message-regex]
-      (is (thrown-with-msg? Exception ?exception-message-regex
-                            (coerce-to-spec ?spec in?)))
-      "a" int? #"\"a\" - failed: parseInt"
-      1.0 int? #"1.0 - failed: parseInt"
-      "[1 2" (from-edn (s/coll-of int?)) #"\"\[1 2\" - failed: read-string"
-      "[1 1.5]" (from-edn (s/coll-of int?)) #"1.5 - failed: int\? in: \[1\]")))
+    (are [?in ?spec ?ex-msg ?ex-data]
+        (let [exception (try (sc/coerce! ?spec ?in)
+                             (catch Exception e (Throwable->map e)))]
+          (is (= ?ex-data (:data exception)))
+          (is (= ?ex-msg (:cause exception))))
+      "a"       ::c/int           "Failed to coerce value" {:spec  ::c/int,
+                                                            :value "a"}
+      :hi       ::c/int           "Failed to coerce value" {:spec  ::c/int,
+                                                            :value :hi}
+      "[1 2"    ::edn-coll-of-int "Failed to coerce value" {:spec  ::edn-coll-of-int,
+                                                            :value "[1 2"}
+      "[1 1.5]" ::edn-coll-of-int "Failed to coerce value" {:spec  ::edn-coll-of-int,
+                                                            :value "[1 1.5]" }))
+
+  (testing "Works with branching specs"
+    (are [?in ?spec ?out]
+        (= ?out (sc/coerce! ?spec ?in))
+      ":a" ::branching :a)))
 
 
 (deftest to-schema
   (testing "Coercions work and are idempotent"
     (are [?in ?schema ?out]
-      (do (is (= ?out (coerce-to-schema ?schema ?in)))
-          (is (= ?out (coerce-to-schema ?schema ?out))))
+        (do (is (= ?out (coerce-to-schema ?schema ?in)))
+            (is (= ?out (coerce-to-schema ?schema ?out))))
 
       "123" ps/Int 123
       "1.5" ps/Num 1.5
@@ -65,9 +98,9 @@
       "[1, 2, 3]" [ps/Int] [1 2 3]))
 
   (testing "Throws good error messages"
-    (are [in? ?schema ?exception-message-regex]
-      (is (thrown-with-msg? Exception ?exception-message-regex
-                            (coerce-to-schema ?schema in?)))
+    (are [?in ?schema ?exception-message-regex]
+        (is (thrown-with-msg? Exception ?exception-message-regex
+                              (coerce-to-schema ?schema ?in)))
       "a" ps/Int #"\(not \(integer"
       "[1, 2" [ps/Int] #"\(not \(sequential"
       "[1.5]" [ps/Int] #"\[\(not \(integer")))


### PR DESCRIPTION
Here's my proposal to resolve #1 . 

The [spec-coerce](https://github.com/wilkerlucio/spec-coerce) library seems to me to be the most complete attempt at leveraging specs for data coercion. However, the interface is a bit more stringent than what cyrus-config has been accustomed to. Essentially, `:spec` should only be provided as a qualified keyword to a registered spec. Bare predicates (like `int?`) don't work in the way that cyrus-config has been using them in its tests and documentation.

So, in addition to deleting the parsing logic from cyrus-config and using `sc/coerce!` in its place, this PR updates the tests and documentation with the required usage thereof. 

Personally, I see this as a positive change, as specs should almost always be registered to keywords using `s/def` anyway. So it's enforcing good code practice to an extent. Furthermore, spec-coerce's model of providing custom coercion decomplects the spec from the coercion:

```clojure
(s/def ::json-coll-of-int (s/coll-of ::c/int)) ;; The spec
(sc/def ::json-coll-of-int json/parse-string)  ;; The coercion
```
vs
```clojure
;; Spec and coercion conflated into one thing
(s/def ::json-coll-of-intn (from-custom-parser json/parse-string (s/coll-of int?))) 
```

This change is also pending a PR I made to spec-coerce.